### PR TITLE
Fix incorrect reshape parameters in _contract

### DIFF
--- a/mdarray-linalg/src/matmul.rs
+++ b/mdarray-linalg/src/matmul.rs
@@ -248,16 +248,18 @@ pub fn _contract<T: Zero + ComplexFloat + MulAdd<Output = T>, La: Layout, Lb: La
     if keep_shape_a.is_empty() && keep_shape_b.is_empty() {
         ab_resh.to_owned().into_dyn()
     } else if keep_shape_a.is_empty() {
+        // Only B has non-contracted indices, reshape to keep_shape_b
         ab_resh
             .view(0, ..)
-            .reshape(keep_shape_a)
+            .reshape(keep_shape_b)
             .to_owned()
             .into_dyn()
             .into()
     } else if keep_shape_b.is_empty() {
+        // Only A has non-contracted indices, reshape to keep_shape_a
         ab_resh
             .view(.., 0)
-            .reshape(keep_shape_b)
+            .reshape(keep_shape_a)
             .to_owned()
             .into_dyn()
             .into()


### PR DESCRIPTION
## Summary
- Fix bug in `_contract` function where reshape used wrong shape parameter
- When `keep_shape_a` is empty, should reshape to `keep_shape_b` (not `keep_shape_a`)
- When `keep_shape_b` is empty, should reshape to `keep_shape_a` (not `keep_shape_b`)

## Problem
When contracting tensors where one tensor has all its indices contracted, the function panics with "length must not change" because it tries to reshape to an empty shape.

Example failing case:
```rust
// A[i,j] * B[j] → C[i]  (B's j is fully contracted)
// Before fix: tried to reshape to keep_shape_b (empty [])
// After fix: correctly reshapes to keep_shape_a ([i])
```

## Test plan
- Verified fix resolves panic in tensor4all-rs test suite
- The logic matches the intent: non-contracted indices from the "other" tensor should determine the output shape

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)