### PR TITLE
Fix floating point comparison in add_outer_her test

### DIFF
--- a/mdarray-linalg/src/testing/matvec/mod.rs
+++ b/mdarray-linalg/src/testing/matvec/mod.rs
@@ -1,3 +1,4 @@
+use approx::assert_relative_eq;
 use mdarray::{DTensor, tensor};
 use num_complex::Complex;
 
@@ -6,6 +7,21 @@ use crate::{
     matvec::{Argmax, MatVec, Outer, VecOps},
     prelude::*,
 };
+
+fn assert_complex_matrix_approx_eq(
+    a: &DTensor<Complex<f64>, 2>,
+    b: &DTensor<Complex<f64>, 2>,
+    epsilon: f64,
+) {
+    assert_eq!(a.shape(), b.shape(), "Matrix shapes don't match");
+    let (m, n) = *a.shape();
+    for i in 0..m {
+        for j in 0..n {
+            assert_relative_eq!(a[[i, j]].re, b[[i, j]].re, epsilon = epsilon);
+            assert_relative_eq!(a[[i, j]].im, b[[i, j]].im, epsilon = epsilon);
+        }
+    }
+}
 
 pub fn test_eval_and_write(bd: impl MatVec<f64, usize, usize>) {
     let n = 3;
@@ -183,7 +199,7 @@ pub fn test_add_outer_her(bd: impl Outer<Complex<f64>, usize, usize>) {
         }
     });
 
-    assert_eq!(a, expected);
+    assert_complex_matrix_approx_eq(&a, &expected, 1e-14);
 }
 
 pub fn test_add_to_scaled_vecvec(bd: impl VecOps<f64, usize>) {


### PR DESCRIPTION
## Summary
Fix the `add_outer_her` test that fails due to floating point precision errors.

## Problem
The test was using exact equality (`assert_eq!`) to compare complex matrices, which fails due to typical floating point arithmetic errors:
- Expected: `3.275` → Actual: `3.2750000000000004`
- Expected: `5.0` → Actual: `4.999999999999999`

## Solution
- Add `assert_complex_matrix_approx_eq` helper function
- Use tolerance-based comparison with `epsilon = 1e-14`
- Compare real and imaginary parts separately with `assert_relative_eq!`

## Test plan
- [x] `cargo test -p mdarray-linalg-blas --test matvec add_outer_her` passes
- [x] `cargo test --workspace` passes

🤖 Generated with [Claude Code](https://claude.ai/code)